### PR TITLE
feat(group): 그룹 생성 및 초대코드 참여 API 구현

### DIFF
--- a/src/main/java/com/gatieottae/backend/api/group/GroupController.java
+++ b/src/main/java/com/gatieottae/backend/api/group/GroupController.java
@@ -1,5 +1,6 @@
 package com.gatieottae.backend.api.group;
 
+import com.gatieottae.backend.api.group.dto.GroupJoinRequestDto;
 import com.gatieottae.backend.api.group.dto.GroupRequestDto;
 import com.gatieottae.backend.api.group.dto.GroupResponseDto;
 import com.gatieottae.backend.domain.group.GroupService;
@@ -34,5 +35,20 @@ public class GroupController {
     ) {
         GroupResponseDto response = groupService.createGroup(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "초대코드로 참여", description = "초대 코드를 입력해 그룹에 참여합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "참여 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "404", description = "코드 불일치/만료"),
+            @ApiResponse(responseCode = "409", description = "이미 멤버")
+    })
+    @PostMapping("/join/code")
+    public ResponseEntity<GroupResponseDto> joinByCode(
+            @Valid @RequestBody GroupJoinRequestDto request,
+            @AuthenticationPrincipal(expression = "id") Long userId
+    ) {
+        return ResponseEntity.ok(groupService.joinByCode(request.getCode(), userId));
     }
 }

--- a/src/main/java/com/gatieottae/backend/api/group/dto/GroupJoinRequestDto.java
+++ b/src/main/java/com/gatieottae/backend/api/group/dto/GroupJoinRequestDto.java
@@ -1,0 +1,10 @@
+package com.gatieottae.backend.api.group.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class GroupJoinRequestDto {
+    @NotBlank
+    private String code;
+}

--- a/src/main/java/com/gatieottae/backend/api/group/dto/GroupResponseDto.java
+++ b/src/main/java/com/gatieottae/backend/api/group/dto/GroupResponseDto.java
@@ -1,5 +1,6 @@
 package com.gatieottae.backend.api.group.dto;
 
+import com.gatieottae.backend.domain.group.Group;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,4 +21,16 @@ public class GroupResponseDto {
     private LocalDate startDate;
     private LocalDate endDate;
     private String inviteCode;
+
+    public static GroupResponseDto from(Group group) {
+        return GroupResponseDto.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .description(group.getDescription())
+                .destination(group.getDestination())
+                .startDate(group.getStartDate())
+                .endDate(group.getEndDate())
+                .inviteCode(group.getInviteCode())
+                .build();
+    }
 }

--- a/src/main/java/com/gatieottae/backend/domain/group/GroupMember.java
+++ b/src/main/java/com/gatieottae/backend/domain/group/GroupMember.java
@@ -4,11 +4,6 @@ import com.gatieottae.backend.common.jpa.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-/**
- * travel_group_member 테이블 매핑 엔티티.
- * - (group_id, member_id) 유니크
- * - role: OWNER/ADMIN/MEMBER (DB CHECK 제약과 일치하도록 Enum 사용)
- */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -27,8 +22,7 @@ public class GroupMember extends BaseTimeEntity {
 
     public enum Role { OWNER, ADMIN, MEMBER }
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY) // BIGSERIAL 매핑
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "group_id", nullable = false)
@@ -40,4 +34,13 @@ public class GroupMember extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 16)
     private Role role;
+
+    // 정적 팩토리
+    public static GroupMember create(Group group, Long memberId, Role role) {
+        return GroupMember.builder()
+                .groupId(group.getId())
+                .memberId(memberId)
+                .role(role)
+                .build();
+    }
 }

--- a/src/main/java/com/gatieottae/backend/domain/group/GroupService.java
+++ b/src/main/java/com/gatieottae/backend/domain/group/GroupService.java
@@ -67,4 +67,18 @@ public class GroupService {
                 .inviteCode(saved.getInviteCode())
                 .build();
     }
+
+    /** 초대코드로 참여 */
+    @Transactional
+    public GroupResponseDto joinByCode(String code, Long userId) {
+        Group group = groupRepository.findByInviteCode(code)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.INVALID_CODE));
+
+        if (groupMemberRepository.existsByGroupIdAndMemberId(group.getId(), userId)) {
+            throw new GroupException(GroupErrorCode.ALREADY_MEMBER);
+        }
+
+        groupMemberRepository.save(GroupMember.create(group, userId, GroupMember.Role.MEMBER));
+        return GroupResponseDto.from(group);
+    }
 }

--- a/src/main/java/com/gatieottae/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/gatieottae/backend/domain/group/exception/GroupErrorCode.java
@@ -8,11 +8,11 @@ import org.springframework.http.HttpStatus;
  * 그룹 관련 에러 코드 정의
  */
 @Getter
-@RequiredArgsConstructor
 public enum GroupErrorCode {
+    GROUP_NAME_DUPLICATED("동일한 이름의 그룹이 이미 존재합니다."),
+    INVALID_CODE("유효하지 않은 초대 코드입니다."),
+    ALREADY_MEMBER("이미 그룹 멤버입니다.");
 
-    GROUP_NAME_DUPLICATED(HttpStatus.CONFLICT, "동일한 이름의 그룹이 이미 존재합니다.");
-
-    private final HttpStatus status;
     private final String message;
+    GroupErrorCode(String message) { this.message = message; }
 }

--- a/src/main/java/com/gatieottae/backend/domain/group/exception/GroupException.java
+++ b/src/main/java/com/gatieottae/backend/domain/group/exception/GroupException.java
@@ -7,7 +7,6 @@ import lombok.Getter;
  */
 @Getter
 public class GroupException extends RuntimeException {
-
     private final GroupErrorCode errorCode;
 
     public GroupException(GroupErrorCode errorCode) {

--- a/src/main/java/com/gatieottae/backend/repository/group/GroupRepository.java
+++ b/src/main/java/com/gatieottae/backend/repository/group/GroupRepository.java
@@ -17,4 +17,5 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
      * 초대코드로 그룹 조회 (참여/유효성 검사에 사용).
      */
     Optional<Group> findByInviteCode(String inviteCode);
+
 }

--- a/src/test/java/com/gatieottae/backend/api/group/controller/GroupControllerJoinByCodeTest.java
+++ b/src/test/java/com/gatieottae/backend/api/group/controller/GroupControllerJoinByCodeTest.java
@@ -1,0 +1,143 @@
+package com.gatieottae.backend.api.group.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.gatieottae.backend.domain.member.Member;
+import com.gatieottae.backend.repository.member.MemberRepository;
+import com.gatieottae.backend.security.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * POST /api/groups/join/code
+ * - 200 정상 참여
+ * - 404 INVALID_CODE (코드 없거나 만료)
+ * - 409 ALREADY_MEMBER (이미 멤버)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class GroupControllerJoinByCodeTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper om;
+
+    @Autowired MemberRepository memberRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired JwtTokenProvider jwtTokenProvider;
+
+    String tokenOwner;  // 그룹 생성자
+    String tokenGuest;  // 초대코드로 참여할 사용자
+
+    @BeforeEach
+    void setup() throws Exception {
+        memberRepository.deleteAll();
+
+        Member owner = memberRepository.save(Member.builder()
+                .username("owner")
+                .passwordHash(passwordEncoder.encode("pw"))
+                .name("오너")
+                .build());
+
+        Member guest = memberRepository.save(Member.builder()
+                .username("guest")
+                .passwordHash(passwordEncoder.encode("pw"))
+                .name("게스트")
+                .build());
+
+        tokenOwner = jwtTokenProvider.generateAccessToken(owner.getUsername(), owner.getId());
+        tokenGuest = jwtTokenProvider.generateAccessToken(guest.getUsername(), guest.getId());
+    }
+
+    private String createGroupAndGetInviteCode(String name, String destination) throws Exception {
+        ObjectNode req = om.createObjectNode();
+        req.put("name", name);
+        req.put("destination", destination);
+        // description/startDate/endDate는 선택
+        String res = mockMvc.perform(
+                        post("/api/groups")
+                                .header("Authorization", "Bearer " + tokenOwner)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(om.writeValueAsString(req))
+                ).andExpect(status().isCreated())
+                .andExpect(jsonPath("$.inviteCode", not(blankOrNullString())))
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode node = om.readTree(res);
+        return node.get("inviteCode").asText();
+    }
+
+    private String joinBody(String code) throws Exception {
+        ObjectNode req = om.createObjectNode();
+        req.put("code", code);
+        return om.writeValueAsString(req);
+    }
+
+    @Nested
+    @DisplayName("POST /api/groups/join/code")
+    class JoinByCode {
+
+        @Test
+        @DisplayName("✅ 초대 코드로 정상 참여 → 200 OK")
+        void join_success_200() throws Exception {
+            String inviteCode = createGroupAndGetInviteCode("제주여행", "제주도");
+
+            mockMvc.perform(
+                            post("/api/groups/join/code")
+                                    .header("Authorization", "Bearer " + tokenGuest)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(joinBody(inviteCode))
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id", notNullValue()))
+                    .andExpect(jsonPath("$.name", is("제주여행")))
+                    .andExpect(jsonPath("$.destination", is("제주도")));
+        }
+
+        @Test
+        @DisplayName("❌ 잘못된 코드 → 404 INVALID_CODE")
+        void invalid_code_404() throws Exception {
+            mockMvc.perform(
+                            post("/api/groups/join/code")
+                                    .header("Authorization", "Bearer " + tokenGuest)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(joinBody("INVALIDXX"))   // 존재하지 않는 코드
+                    )
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code", is("INVALID_CODE")));
+        }
+
+        @Test
+        @DisplayName("❌ 이미 멤버가 재참여 시도 → 409 ALREADY_MEMBER")
+        void already_member_409() throws Exception {
+            String inviteCode = createGroupAndGetInviteCode("부산여행", "부산");
+
+            // 첫 참여: OK
+            mockMvc.perform(
+                    post("/api/groups/join/code")
+                            .header("Authorization", "Bearer " + tokenGuest)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(joinBody(inviteCode))
+            ).andExpect(status().isOk());
+
+            // 재참여: 409
+            mockMvc.perform(
+                            post("/api/groups/join/code")
+                                    .header("Authorization", "Bearer " + tokenGuest)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(joinBody(inviteCode))
+                    )
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code", is("ALREADY_MEMBER")));
+        }
+    }
+}


### PR DESCRIPTION
### 📌 목적 (Why)
- 사용자가 그룹을 생성하고, 초대 코드를 통해 참여할 수 있는 핵심 기능을 제공하기 위함
- 중복 그룹명, 잘못된 코드, 이미 가입된 멤버와 같은 케이스를 명확하게 예외 처리하기 위함

---

### 🔧 변경 사항 (What)
- **도메인**: Group, GroupMember 엔티티 및 Role/정적 팩토리 메서드 추가
- **레포지토리**: existsByOwnerIdAndName, findByInviteCode, existsByGroupIdAndMemberId 메서드 정의
- **서비스**
  - `createGroup()`: 그룹 생성, 초대코드 발급, OWNER 자동 등록
  - `joinByCode()`: 초대코드로 참여, 중복 검증 및 예외 처리
- **컨트롤러**
  - `POST /api/groups`: 그룹 생성
  - `POST /api/groups/join/code`: 초대 코드 참여
- **보안/설정**: JWT 인증 적용
- **예외 처리**: GroupException + GlobalExceptionHandler에 INVALID_CODE, ALREADY_MEMBER, GROUP_NAME_DUPLICATED 매핑
- **테스트**: 통합 테스트로 정상/중복/코드 불일치 케이스 검증

---

### ✅ 테스트 결과 (Test)
- [x] 실패 케이스: 그룹명 중복, 코드 불일치, 이미 멤버일 때
- [x] 통합 테스트: API 201, 200, 404, 409 응답 검증
- [x] Swagger/Postman 수동 테스트 완료

---

### 🔗 이슈 링크 (Related Issues)
- Closes #22 (초대 코드 참여 API)
- Parent: #20 (MVP-2: 그룹 관리 & 홈)