### PR TITLE
feat(group-detail): 그룹 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/gatieottae/backend/api/group/controller/GroupController.java
+++ b/src/main/java/com/gatieottae/backend/api/group/controller/GroupController.java
@@ -1,4 +1,4 @@
-package com.gatieottae.backend.api.group;
+package com.gatieottae.backend.api.group.controller;
 
 import com.gatieottae.backend.api.group.dto.GroupJoinRequestDto;
 import com.gatieottae.backend.api.group.dto.GroupRequestDto;

--- a/src/main/java/com/gatieottae/backend/api/group/controller/GroupDetailController.java
+++ b/src/main/java/com/gatieottae/backend/api/group/controller/GroupDetailController.java
@@ -1,0 +1,21 @@
+package com.gatieottae.backend.api.group.controller;
+
+import com.gatieottae.backend.api.group.dto.GroupDetailResponseDto;
+import com.gatieottae.backend.domain.group.GroupDetailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/groups")
+public class GroupDetailController {
+
+    private final GroupDetailService service;
+
+    @GetMapping("/{groupId}")
+    public GroupDetailResponseDto getGroupDetail(@PathVariable Long groupId,
+                                                 @AuthenticationPrincipal(expression = "id") Long userId) {
+        return service.getGroupDetail(groupId);
+    }
+}

--- a/src/main/java/com/gatieottae/backend/api/group/dto/GroupDetailResponseDto.java
+++ b/src/main/java/com/gatieottae/backend/api/group/dto/GroupDetailResponseDto.java
@@ -1,0 +1,29 @@
+package com.gatieottae.backend.api.group.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Value
+@Builder
+public class GroupDetailResponseDto {
+    Long id;
+    String name;
+    String description;
+    String destination;
+    LocalDate startDate;
+    LocalDate endDate;
+    Long ownerId;
+    int memberCount;
+    List<MemberDto> members;
+
+    @Value
+    @Builder
+    public static class MemberDto {
+        Long id;
+        String displayName; // nickname 우선, 없으면 name
+        String role;        // OWNER / MEMBER
+    }
+}

--- a/src/main/java/com/gatieottae/backend/domain/group/GroupDetailService.java
+++ b/src/main/java/com/gatieottae/backend/domain/group/GroupDetailService.java
@@ -1,0 +1,76 @@
+package com.gatieottae.backend.domain.group;
+
+import com.gatieottae.backend.api.group.dto.GroupDetailResponseDto;
+import com.gatieottae.backend.common.exception.NotFoundException;
+import com.gatieottae.backend.domain.member.Member;
+import com.gatieottae.backend.repository.group.GroupMemberRepository;
+import com.gatieottae.backend.repository.group.GroupRepository;
+import com.gatieottae.backend.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GroupDetailService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final MemberRepository memberRepository;
+
+    public GroupDetailResponseDto getGroupDetail(Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new NotFoundException("Group not found"));
+
+        // 1) 그룹 멤버 로드 (memberId, role만 들어있음)
+        List<GroupMember> gms = groupMemberRepository.findAllByGroupId(groupId);
+
+        // 2) memberId → Member 벌크 조회 후 맵핑
+        List<Long> memberIds = gms.stream().map(GroupMember::getMemberId).toList();
+        Map<Long, Member> membersById = memberRepository.findAllById(memberIds).stream()
+                .collect(Collectors.toMap(Member::getId, m -> m));
+
+        // 3) 정렬: OWNER 우선 → displayName 알파벳 → id 오름차순
+        Comparator<GroupMember> cmp = Comparator
+                .comparing((GroupMember gm) -> gm.getRole() == GroupMember.Role.OWNER ? 0 : 1)
+                .thenComparing(gm -> {
+                    Member m = membersById.get(gm.getMemberId());
+                    String dn = getDisplayName(m);
+                    return dn == null ? "" : dn.toLowerCase();
+                })
+                .thenComparing(GroupMember::getMemberId);
+
+        List<GroupDetailResponseDto.MemberDto> members = gms.stream()
+                .sorted(cmp)
+                .map(gm -> {
+                    Member m = membersById.get(gm.getMemberId());
+                    return GroupDetailResponseDto.MemberDto.builder()
+                            .id(m.getId())
+                            .displayName(getDisplayName(m))   // nickname 우선, 없으면 name
+                            .role(gm.getRole().name())
+                            .build();
+                })
+                .toList();
+
+        return GroupDetailResponseDto.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .description(group.getDescription())
+                .destination(group.getDestination())
+                .startDate(group.getStartDate())
+                .endDate(group.getEndDate())
+                .ownerId(group.getOwnerId())
+                .memberCount(members.size())
+                .members(members)
+                .build();
+    }
+
+    private String getDisplayName(Member m) {
+        String nick = m.getNickname();
+        return (nick != null && !nick.isBlank()) ? nick : m.getName();
+    }
+}

--- a/src/main/java/com/gatieottae/backend/repository/group/GroupMemberRepository.java
+++ b/src/main/java/com/gatieottae/backend/repository/group/GroupMemberRepository.java
@@ -3,10 +3,15 @@ package com.gatieottae.backend.repository.group;
 import com.gatieottae.backend.domain.group.GroupMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
     /**
      * 특정 그룹에 이미 가입되어 있는지 검사 (참여 API 멱등성 확보).
      */
     boolean existsByGroupIdAndMemberId(Long groupId, Long memberId);
+
+    List<GroupMember> findAllByGroupId(Long groupId);
+    List<GroupMember> findByGroupId(Long groupId);
 }

--- a/src/main/java/com/gatieottae/backend/repository/group/projection/GroupMemberBrief.java
+++ b/src/main/java/com/gatieottae/backend/repository/group/projection/GroupMemberBrief.java
@@ -1,0 +1,7 @@
+package com.gatieottae.backend.repository.group.projection;
+
+public interface GroupMemberBrief {
+    Long getId();
+    String getDisplayName();
+    String getRole();
+}


### PR DESCRIPTION
## feat(group-detail): 그룹 상세 조회 API 구현

### 📌 목적 (Why)
- 그룹 상세 화면에서 기본 정보와 구성원 정보를 한 번에 제공하기 위해 상세 조회 API를 추가합니다.

---

### 🔧 구현 내용 (What)
- **컨트롤러**
  - `GET /api/groups/{id}` 엔드포인트 추가 (인증 필요, `@AuthUser Long userId` 주입)
- **서비스**
  - `GroupDetailService#getGroupDetail(groupId)` 구현  
  - 그룹 기본 정보 조회 + 멤버 목록 매핑
- **레포지토리**
  - `GroupMemberRepository`에 `findByGroupId(Long groupId)` 추가 (그룹 멤버 조회)
- **DTO**
  - `GroupDetailResponseDto` 정의
    - `id, name, description, destination, startDate, endDate, ownerId, memberCount, members[]`
    - `members[].displayName`는 `nickname` 우선, 없으면 `name`
    - `members[].role` 포함 (`OWNER`/`MEMBER`)
- **예외 처리**
  - 그룹 미존재 시 `404 Not Found` (`NotFoundException("Group not found")`)

---

### 🧩 응답 예시 (Response)
```json
{
  "id": 123,
  "name": "부산 2박3일",
  "description": "먹방 & 바다",
  "destination": "부산",
  "startDate": "2025-09-10",
  "endDate": "2025-09-12",
  "ownerId": 42,
  "memberCount": 3,
  "members": [
    { "id": 42, "displayName": "민수", "role": "OWNER" },
    { "id": 77, "displayName": "영희", "role": "MEMBER" },
    { "id": 88, "displayName": "철수", "role": "MEMBER" }
  ]
}
```
---
### 🔗 이슈 링크 (Related Issues)
- Closes #24 (그룹 상세 조회 API)
- Parent: #20 (MVP-2: 그룹 관리 & 홈)