### PR TITLE
feat(group): 그룹 수정 API 추가

### DIFF
--- a/src/main/java/com/gatieottae/backend/api/group/controller/GroupController.java
+++ b/src/main/java/com/gatieottae/backend/api/group/controller/GroupController.java
@@ -51,4 +51,21 @@ public class GroupController {
     ) {
         return ResponseEntity.ok(groupService.joinByCode(request.getCode(), userId));
     }
+
+    @Operation(summary = "그룹 수정", description = "OWNER만 그룹 정보를 수정할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "그룹 없음")
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<GroupResponseDto> updateGroup(
+            @PathVariable Long id,
+            @Valid @RequestBody GroupRequestDto request,
+            @AuthenticationPrincipal(expression = "id") Long userId
+    ) {
+        GroupResponseDto response = groupService.updateGroup(id, userId, request);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/gatieottae/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gatieottae/backend/common/exception/GlobalExceptionHandler.java
@@ -124,8 +124,11 @@ public class GlobalExceptionHandler {
         log.warn("Group exception: {} - {}", ex.getErrorCode(), ex.getMessage());
 
         int httpStatus = switch (ex.getErrorCode()) {
-            case INVALID_CODE -> HttpStatus.NOT_FOUND.value();   // 404
-            case ALREADY_MEMBER, GROUP_NAME_DUPLICATED -> HttpStatus.CONFLICT.value(); // 409
+            case INVALID_CODE -> HttpStatus.NOT_FOUND.value();
+            case ALREADY_MEMBER -> HttpStatus.CONFLICT.value();
+            case GROUP_NAME_DUPLICATED -> HttpStatus.CONFLICT.value();
+            case GROUP_NOT_FOUND -> HttpStatus.NOT_FOUND.value();
+            case NO_PERMISSION -> HttpStatus.FORBIDDEN.value();
         };
 
         ApiErrorResponse body = ApiErrorResponse.builder()

--- a/src/main/java/com/gatieottae/backend/domain/group/Group.java
+++ b/src/main/java/com/gatieottae/backend/domain/group/Group.java
@@ -51,4 +51,13 @@ public class Group extends BaseTimeEntity {
     // 초대코드(단일, 만료 없음)
     @Column(name = "invite_code", length = 12, unique = true)
     private String inviteCode;
+
+    public void update(String name, String description, String destination,
+                       LocalDate startDate, LocalDate endDate) {
+        this.name = name;
+        this.description = description;
+        this.destination = destination;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
 }

--- a/src/main/java/com/gatieottae/backend/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/gatieottae/backend/domain/group/exception/GroupErrorCode.java
@@ -1,8 +1,6 @@
 package com.gatieottae.backend.domain.group.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 /**
  * 그룹 관련 에러 코드 정의
@@ -11,7 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum GroupErrorCode {
     GROUP_NAME_DUPLICATED("동일한 이름의 그룹이 이미 존재합니다."),
     INVALID_CODE("유효하지 않은 초대 코드입니다."),
-    ALREADY_MEMBER("이미 그룹 멤버입니다.");
+    ALREADY_MEMBER("이미 그룹 멤버입니다."),
+    GROUP_NOT_FOUND("존재하지 않는 그룹입니다."),
+    NO_PERMISSION("이 그룹을 수정할 권한이 없습니다.");
 
     private final String message;
     GroupErrorCode(String message) { this.message = message; }


### PR DESCRIPTION
### 📌 목적 (Why)
- 그룹의 생성자가 그룹 정보를 수정할 수 있도록 기능 추가
---

### 🔧 구현 내용 (What)
- **컨트롤러**: `PUT /api/groups/{id}` 엔드포인트 추가
- **서비스**: 그룹 수정 로직 구현 (이름/설명/여행지/일정 수정 가능)
- **레포지토리**: 그룹 조회 및 저장 활용
- **보안/검증**: OWNER 권한 확인 후 수정 허용
- **예외 처리**: 
  - 존재하지 않는 그룹 ID → 404
  - 권한 없는 사용자 → 403
  - 잘못된 입력값(날짜 역전 등) → 400

----

🔗 이슈 링크 (Related Issues)
Closes https://github.com/gatieottae/backend/issues/28 (그룹 수정 API)
Parent: https://github.com/gatieottae/backend/issues/20 (MVP-2: 그룹 관리 & 홈)