### PR TITLE
feat: 일정 기능 개발

### DIFF
--- a/src/main/java/com/gatieottae/backend/api/schedule/controller/ScheduleAttendanceController.java
+++ b/src/main/java/com/gatieottae/backend/api/schedule/controller/ScheduleAttendanceController.java
@@ -1,0 +1,28 @@
+package com.gatieottae.backend.api.schedule.controller;
+
+import com.gatieottae.backend.api.schedule.dto.ScheduleDto;
+import com.gatieottae.backend.service.schedule.ScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/schedules/{scheduleId}")
+public class ScheduleAttendanceController {
+
+    private final ScheduleService scheduleService;
+
+    @Operation(summary = "참여 상태 변경", description = "GOING/NOT_GOING/TENTATIVE")
+    @PutMapping("/attendance")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void setAttendance(
+            @PathVariable Long scheduleId,
+            @Valid @RequestBody ScheduleDto.AttendanceReq req,
+            @RequestHeader("X-Member-Id") Long me
+    ) {
+        scheduleService.setAttendance(scheduleId, me, req.status());
+    }
+}

--- a/src/main/java/com/gatieottae/backend/api/schedule/controller/ScheduleAttendanceController.java
+++ b/src/main/java/com/gatieottae/backend/api/schedule/controller/ScheduleAttendanceController.java
@@ -1,11 +1,12 @@
 package com.gatieottae.backend.api.schedule.controller;
 
-import com.gatieottae.backend.api.schedule.dto.ScheduleDto;
 import com.gatieottae.backend.service.schedule.ScheduleService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -15,14 +16,16 @@ public class ScheduleAttendanceController {
 
     private final ScheduleService scheduleService;
 
-    @Operation(summary = "참여 상태 변경", description = "GOING/NOT_GOING/TENTATIVE")
+    public record PutReq(@NotBlank String status) {}
+
+    @Operation(summary = "참여 상태 변경", description = "허용: GOING / NOT_GOING / TENTATIVE")
     @PutMapping("/attendance")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void setAttendance(
+    public ResponseEntity<Void> setAttendance(
             @PathVariable Long scheduleId,
-            @Valid @RequestBody ScheduleDto.AttendanceReq req,
-            @RequestHeader("X-Member-Id") Long me
+            @Valid @RequestBody PutReq body,
+            @AuthenticationPrincipal(expression = "id") Long memberId
     ) {
-        scheduleService.setAttendance(scheduleId, me, req.status());
+        scheduleService.setAttendance(scheduleId, memberId, body.status());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/gatieottae/backend/api/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/gatieottae/backend/api/schedule/controller/ScheduleController.java
@@ -5,45 +5,215 @@ import com.gatieottae.backend.api.schedule.dto.ScheduleDto;
 import com.gatieottae.backend.service.schedule.ScheduleService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
-@RestController
-@RequiredArgsConstructor
-@RequestMapping("/api/groups/{groupId}/schedules")
 @Tag(name = "Schedule", description = "그룹 일정 API")
+@RestController
+@RequestMapping("/api/groups/{groupId}/schedules")
+@RequiredArgsConstructor
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
-    @Operation(summary = "일정 생성", description = "겹침 허용. 생성자 자동 GOING. 겹치는 일정 ID를 응답.")
-    @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public ScheduleDto.CreateRes create(
+    @Operation(
+            summary = "일정 조회(하루 또는 기간)",
+            description = """
+            선택한 날짜의 하루 또는 임의 기간의 일정을 조회합니다.
+
+            📌 사용법
+            - **하루 조회**: `date=2025-09-07`
+            - **기간 조회**: `from=2025-09-07T00:00:00+09:00&to=2025-09-08T00:00:00+09:00`
+            
+            규칙: `end > from` AND `start < to` (겹치는 일정 포함)
+            """,
+            responses = { @ApiResponse(responseCode = "200", description = "OK") }
+    )
+    @GetMapping
+    public ResponseEntity<List<ScheduleDto.Item>> list(
+            @Parameter(description = "그룹 ID", example = "2")
             @PathVariable Long groupId,
-            @Valid @RequestBody ScheduleDto.CreateReq req,
-            @RequestHeader("X-Member-Id") Long me
+
+            @Parameter(description = "YYYY-MM-DD (예: 2025-09-07)", example = "2025-09-07")
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate date,
+
+            @Parameter(description = "포함 시작(ISO-8601)", example = "2025-09-07T00:00:00+09:00")
+            @RequestParam(required = false)
+            OffsetDateTime from,
+
+            @Parameter(description = "제외 끝(ISO-8601)", example = "2025-09-08T00:00:00+09:00")
+            @RequestParam(required = false)
+            OffsetDateTime to,
+
+            // isMine 계산 등에 활용
+            @AuthenticationPrincipal(expression = "id") Long memberId
     ) {
-        return scheduleService.create(groupId, me, req);
+        // 1) date만 온 경우 — 하루 범위로 변환 (오프셋이 없는 LocalDate → 시스템 기본 오프셋 사용)
+        if (date != null && (from == null && to == null)) {
+            // 서버 표준 오프셋을 쓰거나, Asia/Seoul 기준 오프셋을 명시적으로 계산해도 됩니다.
+            ZoneOffset systemOffset = OffsetDateTime.now().getOffset();
+            from = date.atStartOfDay().atOffset(systemOffset);
+            to   = date.plusDays(1).atStartOfDay().atOffset(systemOffset);
+        }
+
+        // 2) 유효성 점검
+        if (from == null || to == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        if (!from.isBefore(to)) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        var items = scheduleService.list(groupId, from, to, memberId, true);
+        return ResponseEntity.ok(items);
     }
 
-    @Operation(summary = "일정 기간 조회", description = "조건: end > from && start < to")
-    @GetMapping
-    public List<ScheduleDto.Item> list(
+    @Operation(
+            summary = "일정 생성",
+            description = """
+            새로운 일정을 생성합니다.
+
+            ✅ 유효성
+            - `startTime` < `endTime`
+            - 동일 그룹/제목/시간 **완전 중복** 금지 (DB 유니크)
+
+            성공 시 생성된 ID와 겹치는 일정 ID 목록을 반환합니다.
+            """,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = ScheduleDto.CreateReq.class),
+                            examples = @ExampleObject(
+                                    name = "성산일출봉 일출",
+                                    value = """
+                    {
+                      "title": "성산일출봉 일출",
+                      "description": "일출 포인트로 이동",
+                      "location": "성산일출봉 주차장",
+                      "startTime": "2025-09-07T05:40:00+09:00",
+                      "endTime":   "2025-09-07T07:30:00+09:00"
+                    }
+                    """
+                            )
+                    )
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "생성 성공"),
+                    @ApiResponse(responseCode = "400", description = "유효성 실패"),
+                    @ApiResponse(responseCode = "401", description = "인증 필요"),
+                    @ApiResponse(responseCode = "409", description = "중복/제약 위반")
+            }
+    )
+    @PostMapping
+    public ResponseEntity<ScheduleDto.CreateRes> create(
+            @Parameter(description = "그룹 ID", example = "2")
             @PathVariable Long groupId,
-            @Parameter(description = "포함 시작(ISO-8601)")
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime from,
-            @Parameter(description = "제외 끝(ISO-8601)")
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime to,
-            @RequestHeader("X-Member-Id") Long me
+            @RequestBody ScheduleDto.CreateReq req,
+            // 생성자 ID(참가자 자동 GOING에 필요)
+            @AuthenticationPrincipal(expression = "id") Long memberId
     ) {
-        return scheduleService.list(groupId, from, to, me, true);
+        var res = scheduleService.create(groupId, memberId, req);
+        return ResponseEntity.status(201).body(res);
+    }
+
+    @Operation(
+            summary = "일정 수정",
+            description = """
+            일정 정보를 수정합니다. 
+            - 수정 가능 필드: `title`, `description`, `location`, `startTime`, `endTime`
+            - 일부만 보낼 경우 해당 필드만 갱신됩니다.
+            - 시간 변경 시 반드시 `startTime < endTime` 이어야 합니다.
+            """,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = ScheduleDto.UpdateReq.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "시간만 수정",
+                                            value = """
+                                        {
+                                          "startTime": "2025-09-07T06:00:00+09:00",
+                                          "endTime":   "2025-09-07T08:00:00+09:00"
+                                        }
+                                        """
+                                    ),
+                                    @ExampleObject(
+                                            name = "제목 + 설명 수정",
+                                            value = """
+                                        {
+                                          "title": "제주 오름 산책",
+                                          "description": "오름 정상에서 일출 감상"
+                                        }
+                                        """
+                                    ),
+                                    @ExampleObject(
+                                            name = "전체 수정",
+                                            value = """
+                                        {
+                                          "title": "성산일출봉 일출",
+                                          "description": "일출 포인트로 이동",
+                                          "location": "성산일출봉 주차장",
+                                          "startTime": "2025-09-07T05:40:00+09:00",
+                                          "endTime":   "2025-09-07T07:30:00+09:00"
+                                        }
+                                        """
+                                    )
+                            }
+                    )
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "수정 성공"),
+                    @ApiResponse(responseCode = "400", description = "검증 실패"),
+                    @ApiResponse(responseCode = "401", description = "인증 필요"),
+                    @ApiResponse(responseCode = "403", description = "권한 없음"),
+                    @ApiResponse(responseCode = "404", description = "일정 없음")
+            }
+    )
+    @PutMapping("/{scheduleId}")
+    public ResponseEntity<ScheduleDto.CreateRes> update(
+            @PathVariable Long groupId,
+            @PathVariable Long scheduleId,
+            @RequestBody ScheduleDto.UpdateReq req,
+            @AuthenticationPrincipal(expression = "id") Long memberId
+    ) {
+        var res = scheduleService.update(groupId, scheduleId, memberId, req);
+        return ResponseEntity.ok(res);
+    }
+
+    @Operation(
+            summary = "일정 삭제",
+            description = "지정한 일정을 삭제합니다. OWNER 또는 작성자만 삭제할 수 있습니다.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "삭제 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 필요"),
+                    @ApiResponse(responseCode = "403", description = "권한 없음"),
+                    @ApiResponse(responseCode = "404", description = "일정 없음")
+            }
+    )
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Void> delete(
+            @PathVariable Long groupId,
+            @PathVariable Long scheduleId,
+            @AuthenticationPrincipal(expression = "id") Long memberId
+    ) {
+        scheduleService.delete(groupId, scheduleId, memberId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/gatieottae/backend/api/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/gatieottae/backend/api/schedule/controller/ScheduleController.java
@@ -1,0 +1,49 @@
+// src/main/java/com/gatieottae/backend/api/schedule/controller/ScheduleController.java
+package com.gatieottae.backend.api.schedule.controller;
+
+import com.gatieottae.backend.api.schedule.dto.ScheduleDto;
+import com.gatieottae.backend.service.schedule.ScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/groups/{groupId}/schedules")
+@Tag(name = "Schedule", description = "그룹 일정 API")
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    @Operation(summary = "일정 생성", description = "겹침 허용. 생성자 자동 GOING. 겹치는 일정 ID를 응답.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ScheduleDto.CreateRes create(
+            @PathVariable Long groupId,
+            @Valid @RequestBody ScheduleDto.CreateReq req,
+            @RequestHeader("X-Member-Id") Long me
+    ) {
+        return scheduleService.create(groupId, me, req);
+    }
+
+    @Operation(summary = "일정 기간 조회", description = "조건: end > from && start < to")
+    @GetMapping
+    public List<ScheduleDto.Item> list(
+            @PathVariable Long groupId,
+            @Parameter(description = "포함 시작(ISO-8601)")
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime from,
+            @Parameter(description = "제외 끝(ISO-8601)")
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime to,
+            @RequestHeader("X-Member-Id") Long me
+    ) {
+        return scheduleService.list(groupId, from, to, me, true);
+    }
+}

--- a/src/main/java/com/gatieottae/backend/api/schedule/dto/ScheduleDto.java
+++ b/src/main/java/com/gatieottae/backend/api/schedule/dto/ScheduleDto.java
@@ -3,6 +3,8 @@ package com.gatieottae.backend.api.schedule.dto;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
+import lombok.Builder;
+
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -80,4 +82,12 @@ public class ScheduleDto {
                 String displayName
         ) {}
     }
+
+    public record UpdateReq(
+            String title,
+            String description,
+            String location,
+            OffsetDateTime startTime,
+            OffsetDateTime endTime
+    ) {}
 }

--- a/src/main/java/com/gatieottae/backend/api/schedule/dto/ScheduleDto.java
+++ b/src/main/java/com/gatieottae/backend/api/schedule/dto/ScheduleDto.java
@@ -1,0 +1,19 @@
+package com.gatieottae.backend.api.schedule.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class ScheduleDto {
+    public record CreateReq(String title, String description, String location,
+                            OffsetDateTime startTime, OffsetDateTime endTime) {}
+    public record CreateRes(Long id, List<Long> overlappedIds) {}
+
+    public record Item(Long id, String title, String location,
+                       OffsetDateTime startTime, OffsetDateTime endTime,
+                       Attending attending, boolean overlap) {
+        public record Attending(long count, List<Member> sample, boolean hasMore, boolean isMine) {}
+        public record Member(Long memberId, String displayName) {}
+    }
+
+    public record AttendanceReq(String status) {} // GOING | NOT_GOING | TENTATIVE
+}

--- a/src/main/java/com/gatieottae/backend/api/schedule/dto/ScheduleDto.java
+++ b/src/main/java/com/gatieottae/backend/api/schedule/dto/ScheduleDto.java
@@ -1,19 +1,83 @@
 package com.gatieottae.backend.api.schedule.dto;
 
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
 import java.time.OffsetDateTime;
 import java.util.List;
 
 public class ScheduleDto {
-    public record CreateReq(String title, String description, String location,
-                            OffsetDateTime startTime, OffsetDateTime endTime) {}
-    public record CreateRes(Long id, List<Long> overlappedIds) {}
 
-    public record Item(Long id, String title, String location,
-                       OffsetDateTime startTime, OffsetDateTime endTime,
-                       Attending attending, boolean overlap) {
-        public record Attending(long count, List<Member> sample, boolean hasMore, boolean isMine) {}
-        public record Member(Long memberId, String displayName) {}
+    // ---------- 요청 DTO ----------
+    @Schema(name = "ScheduleCreateRequest", description = "일정 생성 요청")
+    public record CreateReq(
+            @NotBlank @Size(min = 1, max = 128)
+            @Schema(description = "제목", example = "성산일출봉 일출")
+            String title,
+
+            @Schema(description = "설명", example = "일출 30분 전 집합")
+            String description,
+
+            @Size(max = 255)
+            @Schema(description = "장소", example = "성산읍 성산일출봉 주차장")
+            String location,
+
+            @NotNull
+            @Schema(description = "시작시각(ISO-8601)", example = "2025-09-03T20:40:00Z")
+            OffsetDateTime startTime,
+
+            @NotNull
+            @Schema(description = "종료시각(ISO-8601)", example = "2025-09-03T22:30:00Z")
+            OffsetDateTime endTime
+    ) {}
+
+    @Schema(name = "AttendanceRequest", description = "참여 상태 변경 요청")
+    public record AttendanceReq(
+            @NotBlank
+            @Pattern(regexp = "INVITED|GOING|NOT_GOING|TENTATIVE",
+                    message = "status must be one of INVITED, GOING, NOT_GOING, TENTATIVE")
+            @Schema(description = "참여 상태", example = "GOING")
+            String status
+    ) {}
+
+    // ---------- 응답 DTO ----------
+    @Schema(name = "ScheduleCreateResponse", description = "일정 생성 응답")
+    public record CreateRes(
+            @Schema(description = "생성된 일정 ID", example = "321")
+            Long id,
+            @Schema(description = "겹치는 일정 ID 목록", example = "[12,45]")
+            List<Long> overlappedIds
+    ) {}
+
+    @Schema(name = "ScheduleItem", description = "캘린더 목록 아이템")
+    public record Item(
+            Long id,
+            String title,
+            String location,
+            OffsetDateTime startTime,
+            OffsetDateTime endTime,
+            Attending attending,
+            @Schema(description = "프론트 겹침 하이라이트 플래그", example = "true")
+            boolean overlap
+    ) {
+        @Schema(name = "AttendingSummary")
+        public record Attending(
+                @Schema(description = "참여 인원 수", example = "5")
+                long count,
+                @Schema(description = "표시할 샘플 목록(최대 2)", example = """
+        [{"memberId":11,"displayName":"민수"},{"memberId":14,"displayName":"지현"}]
+        """)
+                List<Member> sample,
+                @Schema(description = "숨겨진 인원 존재 여부", example = "true")
+                boolean hasMore,
+                @Schema(description = "내가 참여중인지", example = "true")
+                boolean isMine
+        ) {}
+
+        @Schema(name = "AttendingMember")
+        public record Member(
+                Long memberId,
+                String displayName
+        ) {}
     }
-
-    public record AttendanceReq(String status) {} // GOING | NOT_GOING | TENTATIVE
 }

--- a/src/main/java/com/gatieottae/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gatieottae/backend/common/exception/GlobalExceptionHandler.java
@@ -12,8 +12,11 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
 
@@ -139,6 +142,15 @@ public class GlobalExceptionHandler {
                 .build();
 
         return ResponseEntity.status(httpStatus).body(body);
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<Map<String, Object>> handle(ResponseStatusException ex) {
+        return ResponseEntity.status(ex.getStatusCode()).body(Map.of(
+                "code", ex.getStatusCode().value(),
+                "message", ex.getReason(),
+                "timestamp", OffsetDateTime.now().toString()
+        ));
     }
 
     /* ========================= Helpers ============================ */

--- a/src/main/java/com/gatieottae/backend/domain/schedule/Schedule.java
+++ b/src/main/java/com/gatieottae/backend/domain/schedule/Schedule.java
@@ -1,0 +1,56 @@
+package com.gatieottae.backend.domain.schedule;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.OffsetDateTime;
+
+/**
+ * 일정 엔티티
+ * - DB: schedule (TIMESTAMPTZ 매핑 → OffsetDateTime)
+ * - 무결성: end_time > start_time (DB CHECK로 보장)
+ */
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@Entity
+@Table(
+        name = "schedule",
+        indexes = {
+                @Index(name = "idx_schedule_group_time", columnList = "group_id,start_time,end_time")
+        }
+        // UNIQUE (group_id, title, start_time, COALESCE(end_time, start_time)) 는 DB 인덱스로 관리
+)
+public class Schedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "group_id", nullable = false)
+    private Long groupId;
+
+    @Column(nullable = false, length = 128)
+    private String title;
+
+    @Column(columnDefinition = "text")
+    private String description;
+
+    @Column(length = 255)
+    private String location;
+
+    @Column(name = "start_time", nullable = false)
+    private OffsetDateTime startTime;
+
+    @Column(name = "end_time")
+    private OffsetDateTime endTime;
+
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    /** DB default now() & trigger로 관리 → 읽기 전용 매핑 */
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    /** DB trigger set_updated_at()로 자동 갱신 → 읽기 전용 매핑 */
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private OffsetDateTime updatedAt;
+}

--- a/src/main/java/com/gatieottae/backend/domain/schedule/ScheduleParticipant.java
+++ b/src/main/java/com/gatieottae/backend/domain/schedule/ScheduleParticipant.java
@@ -1,0 +1,47 @@
+package com.gatieottae.backend.domain.schedule;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 일정 참가자 엔티티
+ * - UNIQUE (schedule_id, member_id) 중복 참가 방지
+ * - 상태 컬럼은 PostgreSQL ENUM(schedule_participant_status)와 매핑
+ */
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@Entity
+@Table(
+        name = "schedule_participant",
+        uniqueConstraints = @UniqueConstraint(name = "uq_schedule_member", columnNames = {"schedule_id","member_id"}),
+        indexes = @Index(name = "idx_sp_schedule_status", columnList = "schedule_id,status,joined_at")
+)
+public class ScheduleParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "schedule_id", nullable = false)
+    private Long scheduleId;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    /**
+     * Hibernate 6: NAMED_ENUM + columnDefinition 으로 DB ENUM과 연결
+     * 주의) Boot 3/Hibernate 6 환경이 아니면 커스텀 타입 필요
+     */
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "status", nullable = false, columnDefinition = "schedule_participant_status")
+    private ScheduleParticipantStatus status;
+
+    /** DB default now() → 읽기 전용 매핑 */
+    @Column(name = "joined_at", insertable = false, updatable = false)
+    private OffsetDateTime joinedAt;
+}

--- a/src/main/java/com/gatieottae/backend/domain/schedule/ScheduleParticipantStatus.java
+++ b/src/main/java/com/gatieottae/backend/domain/schedule/ScheduleParticipantStatus.java
@@ -1,0 +1,12 @@
+package com.gatieottae.backend.domain.schedule;
+
+/**
+ * DB ENUM(schedule_participant_status)과 1:1 매핑되는 애플리케이션 enum.
+ * - INVITED: 초대됨(기본)
+ * - GOING: 참석
+ * - NOT_GOING: 불참
+ * - TENTATIVE: 미정
+ */
+public enum ScheduleParticipantStatus {
+    INVITED, GOING, NOT_GOING, TENTATIVE
+}

--- a/src/main/java/com/gatieottae/backend/repository/schedule/ScheduleParticipantRepository.java
+++ b/src/main/java/com/gatieottae/backend/repository/schedule/ScheduleParticipantRepository.java
@@ -1,0 +1,47 @@
+package com.gatieottae.backend.repository.schedule;
+
+import com.gatieottae.backend.domain.schedule.ScheduleParticipant;
+import com.gatieottae.backend.domain.schedule.ScheduleParticipantStatus;
+import com.gatieottae.backend.repository.schedule.view.AttendeeSampleView;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ScheduleParticipantRepository extends JpaRepository<ScheduleParticipant, Long> {
+
+    /** 참석자 수 (GOING) */
+    @Query("""
+    select count(sp) from ScheduleParticipant sp
+     where sp.scheduleId = :scheduleId and sp.status = 'GOING'
+  """)
+    long countGoing(@Param("scheduleId") Long scheduleId);
+
+    /** 내가 참석중인지 (isMine) */
+    boolean existsByScheduleIdAndMemberIdAndStatus(Long scheduleId, Long memberId, ScheduleParticipantStatus status);
+
+    /**
+     * 참석자 샘플 가져오기 (닉네임 우선)
+     * - Native: member 조인으로 displayName 구성
+     * - Pageable 로 limit 제어 (예: PageRequest.of(0, 2))
+     */
+    @Query(value = """
+    select sp.member_id as memberId,
+           coalesce(m.nickname, m.name) as displayName
+      from schedule_participant sp
+      join member m on m.id = sp.member_id
+     where sp.schedule_id = :scheduleId
+       and sp.status = 'GOING'
+     order by sp.joined_at asc
+  """, nativeQuery = true)
+    List<AttendeeSampleView> findAttendeeSamples(@Param("scheduleId") Long scheduleId, Pageable pageable);
+
+    /** 일정의 GOING 전체 멤버 id (상세 모달 전체 조회 등에 사용 가능) */
+    @Query("""
+    select sp.memberId from ScheduleParticipant sp
+     where sp.scheduleId = :scheduleId and sp.status = 'GOING'
+     order by sp.joinedAt asc
+  """)
+    List<Long> findAllGoingMemberIds(@Param("scheduleId") Long scheduleId);
+}

--- a/src/main/java/com/gatieottae/backend/repository/schedule/ScheduleParticipantRepository.java
+++ b/src/main/java/com/gatieottae/backend/repository/schedule/ScheduleParticipantRepository.java
@@ -4,28 +4,23 @@ import com.gatieottae.backend.domain.schedule.ScheduleParticipant;
 import com.gatieottae.backend.domain.schedule.ScheduleParticipantStatus;
 import com.gatieottae.backend.repository.schedule.view.AttendeeSampleView;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
 import java.util.List;
+import java.util.Optional;
 
 public interface ScheduleParticipantRepository extends JpaRepository<ScheduleParticipant, Long> {
-
-    /** 참석자 수 (GOING) */
     @Query("""
     select count(sp) from ScheduleParticipant sp
      where sp.scheduleId = :scheduleId and sp.status = 'GOING'
   """)
     long countGoing(@Param("scheduleId") Long scheduleId);
 
-    /** 내가 참석중인지 (isMine) */
     boolean existsByScheduleIdAndMemberIdAndStatus(Long scheduleId, Long memberId, ScheduleParticipantStatus status);
 
-    /**
-     * 참석자 샘플 가져오기 (닉네임 우선)
-     * - Native: member 조인으로 displayName 구성
-     * - Pageable 로 limit 제어 (예: PageRequest.of(0, 2))
-     */
+    Optional<ScheduleParticipant> findByScheduleIdAndMemberId(Long scheduleId, Long memberId);
+
     @Query(value = """
     select sp.member_id as memberId,
            coalesce(m.nickname, m.name) as displayName
@@ -37,11 +32,6 @@ public interface ScheduleParticipantRepository extends JpaRepository<SchedulePar
   """, nativeQuery = true)
     List<AttendeeSampleView> findAttendeeSamples(@Param("scheduleId") Long scheduleId, Pageable pageable);
 
-    /** 일정의 GOING 전체 멤버 id (상세 모달 전체 조회 등에 사용 가능) */
-    @Query("""
-    select sp.memberId from ScheduleParticipant sp
-     where sp.scheduleId = :scheduleId and sp.status = 'GOING'
-     order by sp.joinedAt asc
-  """)
-    List<Long> findAllGoingMemberIds(@Param("scheduleId") Long scheduleId);
+
+    void deleteByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/gatieottae/backend/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/gatieottae/backend/repository/schedule/ScheduleRepository.java
@@ -1,18 +1,14 @@
 package com.gatieottae.backend.repository.schedule;
 
 import com.gatieottae.backend.domain.schedule.Schedule;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
-
-    /**
-     * 캘린더 기간과 겹치는 일정 조회 (그룹 단위)
-     * 조건: s.endTime > :from AND s.startTime < :to
-     */
     @Query("""
     select s from Schedule s
      where s.groupId = :groupId
@@ -20,14 +16,10 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
        and s.startTime < :to
      order by s.startTime asc, s.id asc
   """)
-    List<Schedule> findOverlapping(
-            @Param("groupId") Long groupId,
-            @Param("from") OffsetDateTime from,
-            @Param("to") OffsetDateTime to);
+    List<Schedule> findOverlapping(@Param("groupId") Long groupId,
+                                   @Param("from") OffsetDateTime from,
+                                   @Param("to") OffsetDateTime to);
 
-    /**
-     * 방금 생성된 일정과 겹치는 ID 목록 (중복/겹침 표시용)
-     */
     @Query("""
     select s from Schedule s
      where s.groupId = :groupId
@@ -35,9 +27,10 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
        and s.endTime   > :start
        and s.startTime < :end
   """)
-    List<Schedule> findOverlapsOf(
-            @Param("groupId") Long groupId,
-            @Param("scheduleId") Long scheduleId,
-            @Param("start") OffsetDateTime start,
-            @Param("end") OffsetDateTime end);
+    List<Schedule> findOverlapsOf(@Param("groupId") Long groupId,
+                                  @Param("scheduleId") Long scheduleId,
+                                  @Param("start") OffsetDateTime start,
+                                  @Param("end") OffsetDateTime end);
+
+    Optional<Schedule> findByIdAndGroupId(Long id, Long groupId);
 }

--- a/src/main/java/com/gatieottae/backend/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/gatieottae/backend/repository/schedule/ScheduleRepository.java
@@ -1,0 +1,43 @@
+package com.gatieottae.backend.repository.schedule;
+
+import com.gatieottae.backend.domain.schedule.Schedule;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    /**
+     * 캘린더 기간과 겹치는 일정 조회 (그룹 단위)
+     * 조건: s.endTime > :from AND s.startTime < :to
+     */
+    @Query("""
+    select s from Schedule s
+     where s.groupId = :groupId
+       and s.endTime   > :from
+       and s.startTime < :to
+     order by s.startTime asc, s.id asc
+  """)
+    List<Schedule> findOverlapping(
+            @Param("groupId") Long groupId,
+            @Param("from") OffsetDateTime from,
+            @Param("to") OffsetDateTime to);
+
+    /**
+     * 방금 생성된 일정과 겹치는 ID 목록 (중복/겹침 표시용)
+     */
+    @Query("""
+    select s from Schedule s
+     where s.groupId = :groupId
+       and s.id <> :scheduleId
+       and s.endTime   > :start
+       and s.startTime < :end
+  """)
+    List<Schedule> findOverlapsOf(
+            @Param("groupId") Long groupId,
+            @Param("scheduleId") Long scheduleId,
+            @Param("start") OffsetDateTime start,
+            @Param("end") OffsetDateTime end);
+}

--- a/src/main/java/com/gatieottae/backend/repository/schedule/view/AttendeeSampleView.java
+++ b/src/main/java/com/gatieottae/backend/repository/schedule/view/AttendeeSampleView.java
@@ -1,7 +1,6 @@
 package com.gatieottae.backend.repository.schedule.view;
 
-/** 참석자 샘플 표시에 필요한 최소 필드만 투사 */
 public interface AttendeeSampleView {
     Long getMemberId();
-    String getDisplayName(); // COALESCE(nickname, name)
+    String getDisplayName();
 }

--- a/src/main/java/com/gatieottae/backend/repository/schedule/view/AttendeeSampleView.java
+++ b/src/main/java/com/gatieottae/backend/repository/schedule/view/AttendeeSampleView.java
@@ -1,0 +1,7 @@
+package com.gatieottae.backend.repository.schedule.view;
+
+/** 참석자 샘플 표시에 필요한 최소 필드만 투사 */
+public interface AttendeeSampleView {
+    Long getMemberId();
+    String getDisplayName(); // COALESCE(nickname, name)
+}

--- a/src/main/java/com/gatieottae/backend/service/schedule/ScheduleService.java
+++ b/src/main/java/com/gatieottae/backend/service/schedule/ScheduleService.java
@@ -1,0 +1,174 @@
+// src/main/java/com/gatieottae/backend/service/schedule/ScheduleService.java
+package com.gatieottae.backend.service.schedule;
+
+import com.gatieottae.backend.api.schedule.dto.ScheduleDto;
+import com.gatieottae.backend.domain.schedule.Schedule;
+import com.gatieottae.backend.domain.schedule.ScheduleParticipant;
+import com.gatieottae.backend.domain.schedule.ScheduleParticipantStatus;
+import com.gatieottae.backend.repository.schedule.ScheduleParticipantRepository;
+import com.gatieottae.backend.repository.schedule.ScheduleRepository;
+import com.gatieottae.backend.repository.schedule.view.AttendeeSampleView;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final ScheduleRepository scheduleRepo;
+    private final ScheduleParticipantRepository spRepo;
+
+    /**
+     * 일정 생성
+     * - end > start 검증 실패 시 400
+     * - 동일 그룹/제목/시간 완전 중복은 DB 유니크로 차단
+     * - 생성자는 자동 GOING
+     * - 겹치는 일정 ID 목록을 반환하여 UI가 즉시 강조 가능
+     */
+    @Transactional
+    public ScheduleDto.CreateRes create(Long groupId, Long memberId, ScheduleDto.CreateReq req) {
+        // 1) 입력 검증 (클린 에러 메시지)
+        if (!StringUtils.hasText(req.title())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "title is required");
+        }
+        if (req.startTime() == null || req.endTime() == null || !req.startTime().isBefore(req.endTime())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "endTime must be after startTime");
+        }
+
+        // (선택) 그룹 멤버십/권한 검증은 여기서 수행할 수 있음
+        // validateGroupMember(groupId, memberId);
+
+        // 2) 저장
+        Schedule s = Schedule.builder()
+                .groupId(groupId)
+                .title(req.title().trim())
+                .description(req.description())
+                .location(req.location())
+                .startTime(req.startTime())
+                .endTime(req.endTime())
+                .createdBy(memberId)
+                .build();
+        scheduleRepo.save(s);
+
+        // 3) 생성자 자동 참석(GOING) — 멱등을 고려해 존재하면 변경, 없으면 추가
+        upsertAttendance(s.getId(), memberId, ScheduleParticipantStatus.GOING);
+
+        // 4) 겹침 목록 수집
+        List<Long> overlappedIds = scheduleRepo.findOverlapsOf(groupId, s.getId(), req.startTime(), req.endTime())
+                .stream().map(Schedule::getId).toList();
+
+        return new ScheduleDto.CreateRes(s.getId(), overlappedIds);
+    }
+
+    /**
+     * 기간 조회 (달력)
+     * - 조건: end > :from AND start < :to
+     * - 참석자 요약: count + sample(최대 2명, joined_at asc) + isMine
+     */
+    @Transactional(readOnly = true)
+    public List<ScheduleDto.Item> list(Long groupId, OffsetDateTime from, OffsetDateTime to, Long me, boolean markOverlap) {
+        if (from == null || to == null || !from.isBefore(to)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid range: from must be before to");
+        }
+
+        var schedules = scheduleRepo.findOverlapping(groupId, from, to);
+        var result = new ArrayList<ScheduleDto.Item>(schedules.size());
+
+        for (Schedule s : schedules) {
+            long going = spRepo.countGoing(s.getId());
+
+            // sample 2명 (joined_at asc)
+            var samples = spRepo.findAttendeeSamples(s.getId(), PageRequest.of(0, 2));
+            var sampleDtos = samples.stream()
+                    .map(v -> new ScheduleDto.Item.Member(v.getMemberId(), v.getDisplayName()))
+                    .toList();
+
+            boolean isMine = spRepo.existsByScheduleIdAndMemberIdAndStatus(s.getId(), me, ScheduleParticipantStatus.GOING);
+            boolean hasMore = going > sampleDtos.size();
+
+            var attending = new ScheduleDto.Item.Attending(going, sampleDtos, hasMore, isMine);
+
+            result.add(new ScheduleDto.Item(
+                    s.getId(), s.getTitle(), s.getLocation(),
+                    s.getStartTime(), s.getEndTime(),
+                    attending,
+                    markOverlap // 프론트에서 겹침 스타일링 여부에 활용(옵션)
+            ));
+        }
+
+        return result;
+    }
+
+    /**
+     * 참여 상태 설정 (멱등 Upsert)
+     * - 허용: GOING / NOT_GOING / TENTATIVE
+     * - 잘못된 status는 400
+     */
+    @Transactional
+    public void setAttendance(Long scheduleId, Long memberId, String statusText) {
+        ScheduleParticipantStatus status = parseStatus(statusText);
+
+        // (선택) 일정 존재/그룹 멤버십 검증
+        if (!scheduleRepo.existsById(scheduleId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "schedule not found");
+        }
+        // validateGroupMemberBySchedule(scheduleId, memberId);
+
+        upsertAttendance(scheduleId, memberId, status);
+    }
+
+    // ==========================
+    // 내부 유틸
+    // ==========================
+
+    private void upsertAttendance(Long scheduleId, Long memberId, ScheduleParticipantStatus status) {
+        // exists → update, not exists → insert (간단·안전)
+        var opt = spRepo.findAll().stream() // NOTE: 실무에서는 PK/복합키로 조회하는 메서드를 레포에 추가하세요.
+                .filter(x -> x.getScheduleId().equals(scheduleId) && x.getMemberId().equals(memberId))
+                .findFirst();
+
+        ScheduleParticipant sp = opt.orElseGet(() ->
+                ScheduleParticipant.builder()
+                        .scheduleId(scheduleId)
+                        .memberId(memberId)
+                        .status(status)
+                        .build()
+        );
+        sp.setStatus(status);
+        spRepo.save(sp);
+    }
+
+    private ScheduleParticipantStatus parseStatus(String statusText) {
+        if (statusText == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "status is required");
+        }
+        try {
+            // 입력은 대문자 기준 (프론트에서 enum값 그대로 보내도록 합의)
+            return ScheduleParticipantStatus.valueOf(statusText);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid status: " + statusText);
+        }
+    }
+
+    // (선택) 그룹 멤버십 검증 — Security/JWT 붙인 후 활성화
+    @SuppressWarnings("unused")
+    private void validateGroupMember(Long groupId, Long memberId) {
+        // TODO: travel_group_member 존재 여부 확인 후, 없으면 403
+        // throw new ResponseStatusException(HttpStatus.FORBIDDEN, "not a member of the group");
+    }
+
+    @SuppressWarnings("unused")
+    private void validateGroupMemberBySchedule(Long scheduleId, Long memberId) {
+        // TODO: schedule → groupId 로딩 후 validateGroupMember(groupId, memberId)
+    }
+}

--- a/src/main/java/com/gatieottae/backend/service/schedule/ScheduleService.java
+++ b/src/main/java/com/gatieottae/backend/service/schedule/ScheduleService.java
@@ -7,7 +7,6 @@ import com.gatieottae.backend.domain.schedule.ScheduleParticipant;
 import com.gatieottae.backend.domain.schedule.ScheduleParticipantStatus;
 import com.gatieottae.backend.repository.schedule.ScheduleParticipantRepository;
 import com.gatieottae.backend.repository.schedule.ScheduleRepository;
-import com.gatieottae.backend.repository.schedule.view.AttendeeSampleView;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;


### PR DESCRIPTION
## 📌 PR 목적
그룹 일정 CRUD 및 참여 상태 변경 API 구현 + Swagger 예시 추가 + JWT 보호 적용

## ✨ 변경 사항
### Controller
- `ScheduleController`
  - `GET /api/groups/{groupId}/schedules?from&to` (OffsetDateTime 기반, 겹침 규칙: end > from AND start < to)
  - `POST /api/groups/{groupId}/schedules` (생성, 겹침 ID 목록 반환)
  - `PUT /api/groups/{groupId}/schedules/{scheduleId}` (부분 수정 허용: 제목/설명/장소/시간)
  - `DELETE /api/groups/{groupId}/schedules/{scheduleId}`
- `ScheduleAttendanceController`
  - `PUT /api/schedules/{scheduleId}/attendance` (GOING/NOT_GOING/TENTATIVE)

### Service/Repo
- `ScheduleService`
  - `create`, `list`, `update`, `delete`, `setAttendance` 구현
  - 생성자 자동 참석(멱등 upsert)
  - 겹치는 일정 ID 조회
- Repository 쿼리: 기간 겹침 조회, 참석자 카운트/샘플

### Swagger
- 각 엔드포인트에 한글 설명 및 ExampleObject 추가
- 전역 `@SecurityRequirement(name = "bearerAuth")` 적용

## 🧪 테스트 방법
1) Swagger 접속: `http://localhost:8080/swagger-ui/index.html`
2) 오른쪽 상단 **Authorize** → `Bearer <JWT 토큰>` 입력
3) 아래 순서로 확인
   - (생성) POST `/api/groups/2/schedules`
     ```json
     {
       "title": "성산일출봉 일출",
       "description": "일출 포인트로 이동",
       "location": "성산일출봉 주차장",
       "startTime": "2025-09-07T05:40:00+09:00",
       "endTime": "2025-09-07T07:30:00+09:00"
     }
     ```
   - (조회) GET `/api/groups/2/schedules?from=2025-09-07T00:00:00+09:00&to=2025-09-08T00:00:00+09:00`
   - (수정) PUT `/api/groups/2/schedules/{id}`
     ```json
     {
       "title": "성산일출봉 일출(수정)",
       "location": "성산일출봉 입구",
       "startTime": "2025-09-07T06:00:00+09:00",
       "endTime": "2025-09-07T08:00:00+09:00"
     }
     ```
   - (삭제) DELETE `/api/groups/2/schedules/{id}`
   - (참여) PUT `/api/schedules/{id}/attendance`
     ```json
     { "status": "GOING" }
     ```

## 🔗 이슈
Closes #32 