### PR TITLE
feat: 정산/지출 DB 스키마 & 도메인 정의

### DIFF
--- a/src/main/java/com/gatieottae/backend/domain/expense/Expense.java
+++ b/src/main/java/com/gatieottae/backend/domain/expense/Expense.java
@@ -1,0 +1,62 @@
+package com.gatieottae.backend.domain.expense;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 지출(Expense)
+ * - 금액 Long(원 단위)
+ * - shares 합계 = amount (서비스 레벨 검증)
+ */
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "expense", schema = "gatieottae",
+        indexes = {
+                @Index(name = "idx_expense_group_paidat", columnList = "group_id, paid_at")
+        })
+public class Expense {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "group_id", nullable = false)
+    private Long groupId;
+
+    @Column(nullable = false, length = 128)
+    private String title;
+
+    /** 총 지출 금액(원 단위) - NUMERIC→BIGINT 마이그레이션 반영 */
+    @Column(nullable = false)
+    private Long amount;
+
+    /** 지불자 member.id */
+    @Column(name = "paid_by")
+    private Long paidBy;
+
+    @Column(name = "paid_at", nullable = false)
+    private OffsetDateTime paidAt;
+
+    /** DB default now(), trigger 로 관리 */
+    @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    /** DB trigger 로 now() 업데이트 */
+    @Column(name = "updated_at", nullable = false, insertable = false, updatable = false)
+    private OffsetDateTime updatedAt;
+
+    @OneToMany(mappedBy = "expense", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ExpenseShare> shares = new ArrayList<>();
+
+    /** 연관관계 편의 메서드 */
+    public void addShare(ExpenseShare share) {
+        share.setExpense(this);
+        this.shares.add(share);
+    }
+}

--- a/src/main/java/com/gatieottae/backend/domain/expense/ExpenseShare.java
+++ b/src/main/java/com/gatieottae/backend/domain/expense/ExpenseShare.java
@@ -1,0 +1,31 @@
+package com.gatieottae.backend.domain.expense;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 지출 분담 금액
+ * - 동일 expense 내 member 1회만(UNIQUE)
+ */
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "expense_share", schema = "gatieottae",
+        uniqueConstraints = @UniqueConstraint(name = "uk_expense_share_once", columnNames = {"expense_id","member_id"}))
+public class ExpenseShare {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "expense_id", nullable = false)
+    private Expense expense;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    /** 분담금(원 단위) - NUMERIC→BIGINT 마이그레이션 반영 */
+    @Column(name = "share", nullable = false)
+    private Long shareAmount;
+}

--- a/src/main/java/com/gatieottae/backend/domain/expense/Transfer.java
+++ b/src/main/java/com/gatieottae/backend/domain/expense/Transfer.java
@@ -1,0 +1,57 @@
+package com.gatieottae.backend.domain.expense;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 송금(정산) 트랜잭션
+ * - settlement → transfer로 전환된 테이블과 매핑
+ * - 상태 머신: REQUESTED → SENT → CONFIRMED / ROLLED_BACK
+ */
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "transfer", schema = "gatieottae",
+        indexes = {
+                @Index(name = "idx_transfer_group", columnList = "group_id"),
+                @Index(name = "idx_transfer_from_to", columnList = "from_member_id,to_member_id")
+        })
+public class Transfer {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "group_id", nullable = false)
+    private Long groupId;
+
+    @Column(name = "from_member_id", nullable = false)
+    private Long fromMemberId;
+
+    @Column(name = "to_member_id", nullable = false)
+    private Long toMemberId;
+
+    /** 송금 금액(원 단위) */
+    @Column(nullable = false)
+    private Long amount;
+
+    /** DB는 enum 타입, JPA는 문자열로 저장(호환성↑) */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TransferStatus status;
+
+    @Column(name = "proof_url")
+    private String proofUrl;
+
+    private String memo;
+
+    /** DB default now() */
+    @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    /** DB trigger(now()) */
+    @Column(name = "updated_at", nullable = false, insertable = false, updatable = false)
+    private OffsetDateTime updatedAt;
+}

--- a/src/main/java/com/gatieottae/backend/domain/expense/TransferStatus.java
+++ b/src/main/java/com/gatieottae/backend/domain/expense/TransferStatus.java
@@ -1,0 +1,6 @@
+package com.gatieottae.backend.domain.expense;
+
+/** DB enum(gatieottae.transfer_status)과 문자열 매핑 */
+public enum TransferStatus {
+    REQUESTED, SENT, CONFIRMED, ROLLED_BACK
+}

--- a/src/main/java/com/gatieottae/backend/repository/expense/ExpenseRepository.java
+++ b/src/main/java/com/gatieottae/backend/repository/expense/ExpenseRepository.java
@@ -1,0 +1,10 @@
+package com.gatieottae.backend.repository.expense;
+
+import com.gatieottae.backend.domain.expense.Expense;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+    List<Expense> findByGroupIdOrderByPaidAtDesc(Long groupId);
+}

--- a/src/main/java/com/gatieottae/backend/repository/expense/ExpenseShareRepository.java
+++ b/src/main/java/com/gatieottae/backend/repository/expense/ExpenseShareRepository.java
@@ -1,0 +1,10 @@
+package com.gatieottae.backend.repository.expense;
+
+import com.gatieottae.backend.domain.expense.ExpenseShare;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ExpenseShareRepository extends JpaRepository<ExpenseShare, Long> {
+    List<ExpenseShare> findByExpenseId(Long expenseId);
+}

--- a/src/main/java/com/gatieottae/backend/repository/expense/TransferRepository.java
+++ b/src/main/java/com/gatieottae/backend/repository/expense/TransferRepository.java
@@ -1,0 +1,12 @@
+package com.gatieottae.backend.repository.expense;
+
+import com.gatieottae.backend.domain.expense.Transfer;
+import com.gatieottae.backend.domain.expense.TransferStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TransferRepository extends JpaRepository<Transfer, Long> {
+    List<Transfer> findByGroupId(Long groupId);
+    List<Transfer> findByGroupIdAndStatus(Long groupId, TransferStatus status);
+}

--- a/src/main/resources/db/migration/V2025_09_15_01_mvp5_expense.sql
+++ b/src/main/resources/db/migration/V2025_09_15_01_mvp5_expense.sql
@@ -1,0 +1,63 @@
+-- ============================================================
+-- Flyway Migration: Update expense & settlement schema
+-- ============================================================
+
+-- 1. expense.amount / expense_share.share 컬럼 타입 변경 (NUMERIC → BIGINT)
+ALTER TABLE gatieottae.expense
+ALTER COLUMN amount TYPE BIGINT USING ROUND(amount);
+
+ALTER TABLE gatieottae.expense_share
+ALTER COLUMN share TYPE BIGINT USING ROUND(share);
+
+-- 2. settlement → transfer 테이블로 리네임
+ALTER TABLE gatieottae.settlement RENAME TO transfer;
+
+-- 3. transfer 테이블 컬럼 구조 확장
+ALTER TABLE gatieottae.transfer
+    RENAME COLUMN from_member TO from_member_id;
+
+ALTER TABLE gatieottae.transfer
+    RENAME COLUMN to_member TO to_member_id;
+
+-- 기존 settled_at → created_at 으로 리네임
+ALTER TABLE gatieottae.transfer
+    RENAME COLUMN settled_at TO created_at;
+
+-- 상태 컬럼 추가 (REQUESTED, SENT, CONFIRMED, ROLLED_BACK)
+DO $$ BEGIN
+CREATE TYPE gatieottae.transfer_status AS ENUM ('REQUESTED','SENT','CONFIRMED','ROLLED_BACK');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+ALTER TABLE gatieottae.transfer
+    ADD COLUMN status transfer_status NOT NULL DEFAULT 'REQUESTED';
+
+-- 증빙 URL / 메모 추가
+ALTER TABLE gatieottae.transfer
+    ADD COLUMN proof_url TEXT,
+    ADD COLUMN memo TEXT;
+
+-- updated_at 추가
+ALTER TABLE gatieottae.transfer
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+-- 4. 트리거: updated_at 자동 갱신
+DROP TRIGGER IF EXISTS trg_expense_set_updated_at ON gatieottae.expense;
+CREATE TRIGGER trg_expense_set_updated_at
+    BEFORE UPDATE ON gatieottae.expense
+    FOR EACH ROW EXECUTE FUNCTION gatieottae.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_expense_share_set_updated_at ON gatieottae.expense_share;
+CREATE TRIGGER trg_expense_share_set_updated_at
+    BEFORE UPDATE ON gatieottae.expense_share
+    FOR EACH ROW EXECUTE FUNCTION gatieottae.set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_transfer_set_updated_at ON gatieottae.transfer;
+CREATE TRIGGER trg_transfer_set_updated_at
+    BEFORE UPDATE ON gatieottae.transfer
+    FOR EACH ROW EXECUTE FUNCTION gatieottae.set_updated_at();
+
+-- ============================================================
+-- 인덱스 최적화
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_transfer_group ON gatieottae.transfer(group_id);
+CREATE INDEX IF NOT EXISTS idx_transfer_from_to ON gatieottae.transfer(from_member_id, to_member_id);


### PR DESCRIPTION
### 📌 목적 (Why)
- 정산/지출 관리 기능의 기반 데이터 구조 정의
- DB 스키마와 JPA 도메인 매핑을 통해 이후 CRUD/정산 로직 구현 준비

---

### 🔧 변경 사항 (What)
- **Flyway 마이그레이션**
  - `settlement` → `transfer` 테이블 리네임
  - 금액 컬럼 `NUMERIC(12,2)` → `BIGINT` 변환
  - `status`(ENUM), `proof_url`, `memo`, `updated_at` 컬럼 추가
  - `updated_at` 자동 갱신 트리거 및 인덱스 생성

- **도메인(Entity)**
  - `Expense`, `ExpenseShare`, `Transfer`, `TransferStatus` 엔티티 추가
  - 연관관계 매핑 (`Expense` ↔ `ExpenseShare` 1:N)
  - DB 트리거 기반 시간 컬럼 매핑 (`createdAt`, `updatedAt`)

- **레포지토리**
  - `ExpenseRepository`, `ExpenseShareRepository`, `TransferRepository` 스켈레톤 추가
 

---

### 🔗 이슈 링크 (Related Issues)
- Parent: #MVP-5 (정산/지출 관리) 
- Related: #43 (정산/지출 관리 API)
 