### PR TITLE
feat(expense-crud): implement Expense CRUD API with validation

### DIFF
--- a/src/main/java/com/gatieottae/backend/api/expense/controller/ExpenseController.java
+++ b/src/main/java/com/gatieottae/backend/api/expense/controller/ExpenseController.java
@@ -1,0 +1,52 @@
+package com.gatieottae.backend.api.expense.controller;
+
+import com.gatieottae.backend.api.expense.dto.ExpenseRequestDto;
+import com.gatieottae.backend.api.expense.dto.ExpenseResponseDto;
+import com.gatieottae.backend.service.expense.ExpenseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Expense API", description = "지출 CRUD API")
+@RestController
+@RequestMapping("/api/expenses")
+@RequiredArgsConstructor
+public class ExpenseController {
+
+    private final ExpenseService expenseService;
+
+    @Operation(summary = "지출 등록")
+    @PostMapping
+    public ResponseEntity<ExpenseResponseDto> create(@RequestBody ExpenseRequestDto request) {
+        return ResponseEntity.ok(expenseService.createExpense(request));
+    }
+
+    @Operation(summary = "지출 단건 조회")
+    @GetMapping("/{id}")
+    public ResponseEntity<ExpenseResponseDto> get(@PathVariable Long id) {
+        return ResponseEntity.ok(expenseService.getExpense(id));
+    }
+
+    @Operation(summary = "그룹별 지출 목록 조회")
+    @GetMapping("/group/{groupId}")
+    public ResponseEntity<List<ExpenseResponseDto>> list(@PathVariable Long groupId) {
+        return ResponseEntity.ok(expenseService.getExpensesByGroup(groupId));
+    }
+
+    @Operation(summary = "지출 수정")
+    @PutMapping("/{id}")
+    public ResponseEntity<ExpenseResponseDto> update(@PathVariable Long id, @RequestBody ExpenseRequestDto request) {
+        return ResponseEntity.ok(expenseService.updateExpense(id, request));
+    }
+
+    @Operation(summary = "지출 삭제")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        expenseService.deleteExpense(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/gatieottae/backend/api/expense/dto/ExpenseRequestDto.java
+++ b/src/main/java/com/gatieottae/backend/api/expense/dto/ExpenseRequestDto.java
@@ -1,0 +1,33 @@
+package com.gatieottae.backend.api.expense.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class ExpenseRequestDto {
+
+    @Schema(description = "그룹 ID", example = "1")
+    private Long groupId;
+
+    @Schema(description = "지출 제목", example = "숙소 예약")
+    private String title;
+
+    @Schema(description = "총 지출 금액", example = "240000")
+    private Long amount;
+
+    @Schema(description = "지불자 memberId", example = "101")
+    private Long paidBy;
+
+    @Schema(description = "분담 내역")
+    private List<ShareDto> shares;
+
+    @Getter @Setter
+    @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class ShareDto {
+        private Long memberId;
+        private Long shareAmount;
+    }
+}

--- a/src/main/java/com/gatieottae/backend/api/expense/dto/ExpenseResponseDto.java
+++ b/src/main/java/com/gatieottae/backend/api/expense/dto/ExpenseResponseDto.java
@@ -1,0 +1,25 @@
+package com.gatieottae.backend.api.expense.dto;
+
+import lombok.*;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class ExpenseResponseDto {
+    private Long id;
+    private Long groupId;
+    private String title;
+    private Long amount;
+    private Long paidBy;
+    private OffsetDateTime paidAt;
+    private List<ShareDto> shares;
+
+    @Getter @Setter
+    @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class ShareDto {
+        private Long memberId;
+        private Long shareAmount;
+    }
+}

--- a/src/main/java/com/gatieottae/backend/service/expense/ExpenseService.java
+++ b/src/main/java/com/gatieottae/backend/service/expense/ExpenseService.java
@@ -1,0 +1,113 @@
+package com.gatieottae.backend.service.expense;
+
+import com.gatieottae.backend.api.expense.dto.ExpenseRequestDto;
+import com.gatieottae.backend.api.expense.dto.ExpenseResponseDto;
+import com.gatieottae.backend.domain.expense.Expense;
+import com.gatieottae.backend.domain.expense.ExpenseShare;
+import com.gatieottae.backend.repository.expense.ExpenseRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ExpenseService {
+
+    private final ExpenseRepository expenseRepository;
+
+    public ExpenseResponseDto createExpense(ExpenseRequestDto request) {
+        // 1. 분담금 합계 검증
+        long totalShares = request.getShares().stream()
+                .mapToLong(ExpenseRequestDto.ShareDto::getShareAmount)
+                .sum();
+
+        if (totalShares != request.getAmount()) {
+            throw new IllegalArgumentException("분담금 합계가 총 지출 금액과 일치하지 않습니다.");
+        }
+
+        // 2. 엔티티 생성
+        Expense expense = Expense.builder()
+                .groupId(request.getGroupId())
+                .title(request.getTitle())
+                .amount(request.getAmount())
+                .paidBy(request.getPaidBy())
+                .paidAt(OffsetDateTime.now())
+                .build();
+
+        request.getShares().forEach(s ->
+                expense.addShare(
+                        ExpenseShare.builder()
+                                .memberId(s.getMemberId())
+                                .shareAmount(s.getShareAmount())
+                                .build()
+                )
+        );
+
+        // 3. 저장
+        Expense saved = expenseRepository.save(expense);
+        return toResponse(saved);
+    }
+
+    public ExpenseResponseDto getExpense(Long id) {
+        Expense expense = expenseRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Expense not found"));
+        return toResponse(expense);
+    }
+
+    public List<ExpenseResponseDto> getExpensesByGroup(Long groupId) {
+        return expenseRepository.findByGroupIdOrderByPaidAtDesc(groupId).stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    public ExpenseResponseDto updateExpense(Long id, ExpenseRequestDto request) {
+        Expense expense = expenseRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Expense not found"));
+
+        expense.setTitle(request.getTitle());
+        expense.setAmount(request.getAmount());
+        expense.setPaidBy(request.getPaidBy());
+
+        // shares 교체
+        expense.getShares().clear();
+        request.getShares().forEach(s ->
+                expense.addShare(
+                        ExpenseShare.builder()
+                                .memberId(s.getMemberId())
+                                .shareAmount(s.getShareAmount())
+                                .build()
+                )
+        );
+
+        return toResponse(expense);
+    }
+
+    public void deleteExpense(Long id) {
+        expenseRepository.deleteById(id);
+    }
+
+    private ExpenseResponseDto toResponse(Expense e) {
+        return ExpenseResponseDto.builder()
+                .id(e.getId())
+                .groupId(e.getGroupId())
+                .title(e.getTitle())
+                .amount(e.getAmount())
+                .paidBy(e.getPaidBy())
+                .paidAt(e.getPaidAt())
+                .shares(
+                        e.getShares().stream()
+                                .map(s -> ExpenseResponseDto.ShareDto.builder()
+                                        .memberId(s.getMemberId())
+                                        .shareAmount(s.getShareAmount())
+                                        .build())
+                                .collect(Collectors.toList())
+                )
+                .build();
+    }
+}


### PR DESCRIPTION
### 📌 목적 (Why)
- 정산/지출 관리 기능의 CRUD API 제공

---

### 🔧 변경 사항 (What)
- **API**: ExpenseController (`/api/expenses`) CRUD 엔드포인트 추가
- **서비스**: ExpenseService 작성 (분담금 합계 검증 포함)
- **DTO**: ExpenseRequest/ExpenseResponse 정의
- **Swagger**: 각 엔드포인트 summary/description 추가

---

### ✅ 테스트 결과 (Test)
- [x] `POST /api/expenses` 정상 등록
- [x] `GET /api/expenses/{id}` 단건 조회 성공
- [x] `GET /api/expenses/group/{groupId}` 그룹별 리스트 조회
- [x] `PUT /api/expenses/{id}` 수정 성공
- [x] `DELETE /api/expenses/{id}` 삭제 성공

---

### 🔗 이슈 링크 (Related Issues)
- Parent: #42 (MVP-5: 정산/지출)
- Related: #43 (정산/지출 관리 API)