### PR TITLE
feat(settlement): add settlement calculation API 

### DIFF
--- a/src/main/java/com/gatieottae/backend/api/settlement/controller/SettlementController.java
+++ b/src/main/java/com/gatieottae/backend/api/settlement/controller/SettlementController.java
@@ -1,0 +1,24 @@
+package com.gatieottae.backend.api.settlement.controller;
+
+import com.gatieottae.backend.api.settlement.dto.SettlementResponseDto;
+import com.gatieottae.backend.service.settlement.SettlementService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Settlement API", description = "정산 계산 스냅샷")
+@RestController
+@RequestMapping("/api/settlements")
+@RequiredArgsConstructor
+public class SettlementController {
+
+    private final SettlementService settlementService;
+
+    @Operation(summary = "그룹 정산 계산", description = "멤버별 잔액표와 송금 초안 리스트를 반환한다.")
+    @GetMapping("/{groupId}")
+    public ResponseEntity<SettlementResponseDto> calculate(@PathVariable Long groupId) {
+        return ResponseEntity.ok(settlementService.calculate(groupId));
+    }
+}

--- a/src/main/java/com/gatieottae/backend/api/settlement/dto/SettlementResponseDto.java
+++ b/src/main/java/com/gatieottae/backend/api/settlement/dto/SettlementResponseDto.java
@@ -1,0 +1,24 @@
+package com.gatieottae.backend.api.settlement.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class SettlementResponseDto {
+
+    @Schema(description = "멤버별 잔액표 (memberId -> 잔액[원])")
+    private Map<Long, Long> balances;
+
+    @Schema(description = "송금 초안 목록 (음수→양수 매칭)")
+    private List<TransferDraft> transfersDraft;
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class TransferDraft {
+        private Long fromMemberId;  // 보낼 사람(채무자)
+        private Long toMemberId;    // 받을 사람(채권자)
+        private Long amount;        // 원 단위
+    }
+}

--- a/src/main/java/com/gatieottae/backend/repository/expense/ExpenseQueryRepository.java
+++ b/src/main/java/com/gatieottae/backend/repository/expense/ExpenseQueryRepository.java
@@ -1,0 +1,28 @@
+package com.gatieottae.backend.repository.expense;
+
+import com.gatieottae.backend.domain.expense.Expense;
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+
+@Repository
+public class ExpenseQueryRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    /** 그룹 지출과 share를 fetch join으로 한번에 */
+    public List<Expense> findExpensesWithSharesByGroupId(Long groupId) {
+        return em.createQuery("""
+                select distinct e
+                from Expense e
+                left join fetch e.shares s
+                where e.groupId = :gid
+                order by e.paidAt desc
+                """, Expense.class)
+                .setParameter("gid", groupId)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/gatieottae/backend/service/settlement/SettlementService.java
+++ b/src/main/java/com/gatieottae/backend/service/settlement/SettlementService.java
@@ -1,0 +1,81 @@
+package com.gatieottae.backend.service.settlement;
+
+import com.gatieottae.backend.api.settlement.dto.SettlementResponseDto;
+import com.gatieottae.backend.domain.expense.Expense;
+import com.gatieottae.backend.domain.expense.ExpenseShare;
+import com.gatieottae.backend.repository.expense.ExpenseQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SettlementService {
+
+    private final ExpenseQueryRepository expenseQueryRepository;
+
+    public SettlementResponseDto calculate(Long groupId) {
+        List<Expense> expenses = expenseQueryRepository.findExpensesWithSharesByGroupId(groupId);
+
+        // 1) 잔액표 계산
+        Map<Long, Long> balances = new HashMap<>();
+        for (Expense e : expenses) {
+            // 지불자 +
+            balances.merge(e.getPaidBy(), e.getAmount(), Long::sum);
+            // 분담자 -
+            for (ExpenseShare s : e.getShares()) {
+                balances.merge(s.getMemberId(), -s.getShareAmount(), Long::sum);
+            }
+        }
+
+        // 없을 수 있는 멤버(지불만/분담만)도 모두 포함됨
+
+        // 2) 양수/음수 분리
+        List<Map.Entry<Long, Long>> creditors = balances.entrySet().stream()
+                .filter(it -> it.getValue() > 0)
+                .sorted((a,b) -> Long.compare(b.getValue(), a.getValue())) // 많이 받을 사람부터
+                .collect(Collectors.toList());
+
+        List<Map.Entry<Long, Long>> debtors = balances.entrySet().stream()
+                .filter(it -> it.getValue() < 0)
+                .sorted((a,b) -> Long.compare(a.getValue(), b.getValue())) // 많이 낼 사람(더 음수)부터
+                .collect(Collectors.toList());
+
+        // 3) 투포인터 매칭 (그리디)
+        int i = 0, j = 0;
+        List<SettlementResponseDto.TransferDraft> drafts = new ArrayList<>();
+
+        while (i < debtors.size() && j < creditors.size()) {
+            var d = debtors.get(i);
+            var c = creditors.get(j);
+            long debt = -d.getValue();   // 음수 → 양수
+            long credit = c.getValue();  // 양수
+
+            long pay = Math.min(debt, credit);
+            if (pay > 0) {
+                drafts.add(SettlementResponseDto.TransferDraft.builder()
+                        .fromMemberId(d.getKey())
+                        .toMemberId(c.getKey())
+                        .amount(pay)
+                        .build());
+                // 잔액 갱신
+                d.setValue(d.getValue() + pay);      // 음수 + pay (0으로 향함)
+                c.setValue(c.getValue() - pay);      // 양수 - pay (0으로 향함)
+            }
+
+            if (d.getValue() == 0) i++;
+            if (c.getValue() == 0) j++;
+        }
+
+        // 4) 응답
+        // (정렬/표시용으로 balances를 memberId 오름차순으로 정리해도 됨)
+        return SettlementResponseDto.builder()
+                .balances(balances)
+                .transfersDraft(drafts)
+                .build();
+    }
+}

--- a/src/test/java/com/gatieottae/backend/service/settlement/SettlementServiceTest.java
+++ b/src/test/java/com/gatieottae/backend/service/settlement/SettlementServiceTest.java
@@ -1,0 +1,53 @@
+package com.gatieottae.backend.service.settlement;
+
+import com.gatieottae.backend.api.settlement.dto.SettlementResponseDto;
+import com.gatieottae.backend.domain.expense.Expense;
+import com.gatieottae.backend.domain.expense.ExpenseShare;
+import com.gatieottae.backend.repository.expense.ExpenseQueryRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class SettlementServiceTest {
+
+    @Test
+    void calculate_balances_and_drafts_exact() {
+        ExpenseQueryRepository repo = mock(ExpenseQueryRepository.class);
+        SettlementService sut = new SettlementService(repo);
+
+        // given: 4명, 총 3건 지출
+        Expense e1 = Expense.builder().id(1L).groupId(1L).title("숙소").amount(240_000L).paidBy(1L).paidAt(OffsetDateTime.now()).build();
+        e1.addShare(ExpenseShare.builder().memberId(1L).shareAmount(60_000L).build());
+        e1.addShare(ExpenseShare.builder().memberId(2L).shareAmount(60_000L).build());
+        e1.addShare(ExpenseShare.builder().memberId(3L).shareAmount(60_000L).build());
+        e1.addShare(ExpenseShare.builder().memberId(4L).shareAmount(60_000L).build());
+
+        Expense e2 = Expense.builder().id(2L).groupId(1L).title("렌터카").amount(120_000L).paidBy(2L).paidAt(OffsetDateTime.now()).build();
+        e2.addShare(ExpenseShare.builder().memberId(1L).shareAmount(30_000L).build());
+        e2.addShare(ExpenseShare.builder().memberId(2L).shareAmount(30_000L).build());
+        e2.addShare(ExpenseShare.builder().memberId(3L).shareAmount(30_000L).build());
+        e2.addShare(ExpenseShare.builder().memberId(4L).shareAmount(30_000L).build());
+
+        Expense e3 = Expense.builder().id(3L).groupId(1L).title("저녁").amount(40_000L).paidBy(1L).paidAt(OffsetDateTime.now()).build();
+        e3.addShare(ExpenseShare.builder().memberId(1L).shareAmount(20_000L).build());
+        e3.addShare(ExpenseShare.builder().memberId(3L).shareAmount(20_000L).build());
+
+        when(repo.findExpensesWithSharesByGroupId(1L)).thenReturn(List.of(e1, e2, e3));
+
+        // when
+        SettlementResponseDto res = sut.calculate(1L);
+
+        // then: balances 합은 0
+        long sum = res.getBalances().values().stream().mapToLong(Long::longValue).sum();
+        assertThat(sum).isZero();
+
+        // 특정 멤버의 잔액 검증(예: 1L은 더 많이 냄 → 채권자)
+        // 실제 값은 위 시나리오 계산에 따라 양수/음수로 나와야 함
+        assertThat(res.getBalances()).isNotEmpty();
+        assertThat(res.getTransfersDraft()).isNotEmpty();
+    }
+}


### PR DESCRIPTION
### 📌 목적 (Why)
- 그룹 단위 정산 스냅샷 제공(잔액표 + 송금 초안)

### 🔧 변경 사항 (What)
- **Service**: SettlementService (원 단위 정확 계산)
- **Repository**: ExpenseQueryRepository (fetch join)
- **API**: GET /api/settlements/{groupId}
- **DTO**: SettlementResponse, TransferDraft

### ✅ 테스트 결과 (Test)
- [x] 합=0 보존
- [x] 4인 시나리오 잔액/드래프트 생성
- [x] Swagger 호출 확인

### 🔗 이슈 링크 (Related Issues)
- Parent: #42 (MVP-5: 정산/지출)
- Related: #43 (정산/지출 관리 API)