### PR TITLE
feat:  정산/송금 이벤트를 Redis Pub/Sub → WebSocket으로 실시간 전파

### DIFF
--- a/src/main/java/com/gatieottae/backend/api/transfer/dto/TransferWsDto.java
+++ b/src/main/java/com/gatieottae/backend/api/transfer/dto/TransferWsDto.java
@@ -1,0 +1,26 @@
+package com.gatieottae.backend.api.transfer.dto;
+
+import com.gatieottae.backend.domain.expense.TransferStatus;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+
+/** 브라우저로 쏴줄 WS 페이로드 표준 */
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class TransferWsDto {
+
+    public enum Type {
+        REQUESTED, SENT, CONFIRMED, ROLLED_BACK, NUDGE
+    }
+
+    private Type type;             // 이벤트 유형
+    private Long groupId;
+    private Long fromMemberId;
+    private Long toMemberId;
+    private Long amount;           // 원 단위
+    private TransferStatus status; // 상태 변경 시 최종 상태(선택)
+    private String memo;           // 선택
+    private Long actorMemberId;    // 이벤트를 수행한 사용자
+    private OffsetDateTime occurredAt;
+}

--- a/src/main/java/com/gatieottae/backend/infra/notification/NotificationTopics.java
+++ b/src/main/java/com/gatieottae/backend/infra/notification/NotificationTopics.java
@@ -1,8 +1,33 @@
 package com.gatieottae.backend.infra.notification;
 
+/**
+ * Redis Pub/Sub 채널 네이밍 규칙과 패턴 집합
+ * - 기존 notif:* 유지
+ * - transfers:* (정산/송금 알림) 추가
+ */
 public final class NotificationTopics {
     private NotificationTopics() {}
-    public static String groupTopic(Long groupId) { return "notif:group:" + groupId; }
-    public static String userTopic(Long memberId) { return "notif:user:"  + memberId; }
-    public static final String PATTERN_ALL = "notif:*"; // 구독 패턴
+
+    public static final String PREFIX_NOTIF_GROUP = "notif:group:"; // notif:group:{groupId}
+    public static final String PREFIX_NOTIF_USER  = "notif:user:";  // notif:user:{memberId}
+    public static final String PATTERN_ALL        = "notif:*";
+
+    public static String groupTopic(Long groupId) { return PREFIX_NOTIF_GROUP + groupId; }
+    public static String userTopic(Long memberId) { return PREFIX_NOTIF_USER + memberId; }
+
+    public static final String PREFIX_TRANSFERS_GROUP = "transfers:"; // transfers:{groupId}
+    public static final String PATTERN_TRANSFERS_ALL  = "transfers:*";
+
+    /** 정산/송금 이벤트 채널명: transfers:{groupId} */
+    public static String transfersTopic(Long groupId) { return PREFIX_TRANSFERS_GROUP + groupId; }
+
+    /** WebSocket destination (group broadcast): /topic/groups/{groupId}/transfers */
+    public static String wsTransfersDestination(Long groupId) {
+        return "/topic/groups/" + groupId + "/transfers";
+    }
+
+    /** 개인 알림을 transfers 이벤트로도 내려주고 싶을 때 재사용 (기존 규칙과 일관성) */
+    public static String wsUserNotificationDestination(Long memberId) {
+        return "/topic/notifications/" + memberId;
+    }
 }

--- a/src/main/java/com/gatieottae/backend/infra/redis/TransferEventPublisher.java
+++ b/src/main/java/com/gatieottae/backend/infra/redis/TransferEventPublisher.java
@@ -1,0 +1,31 @@
+package com.gatieottae.backend.infra.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gatieottae.backend.api.transfer.dto.TransferWsDto;
+import com.gatieottae.backend.infra.notification.NotificationTopics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TransferEventPublisher {
+
+    private final StringRedisTemplate redis;
+    private final ObjectMapper om;
+
+    /** 그룹 단위로 transfers 이벤트 발행 */
+    public void publish(TransferWsDto payload) {
+        try {
+            String channel = NotificationTopics.transfersTopic(payload.getGroupId());
+            String json = om.writeValueAsString(payload);
+            redis.convertAndSend(channel, json);
+            log.debug("[Transfers] publish channel={} payload={}", channel, json);
+        } catch (Exception e) {
+            // 알림은 비핵심: 로깅만 하고 비즈니스 트랜잭션에 영향 주지 않음
+            log.warn("[Transfers] failed to publish", e);
+        }
+    }
+}

--- a/src/main/java/com/gatieottae/backend/infra/redis/TransferRedisSubscriber.java
+++ b/src/main/java/com/gatieottae/backend/infra/redis/TransferRedisSubscriber.java
@@ -1,0 +1,59 @@
+package com.gatieottae.backend.infra.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gatieottae.backend.api.transfer.dto.TransferWsDto;
+import com.gatieottae.backend.infra.notification.NotificationTopics;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Redis Pub/Sub 구독 → 각 인스턴스의 WebSocket 세션으로 팬아웃
+ * - 그룹 브로드캐스트: /topic/groups/{groupId}/transfers
+ * - (옵션) 개인 알림도 함께 보낼 경우 /topic/notifications/{memberId} 사용
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TransferRedisSubscriber implements MessageListener {
+
+    private final RedisMessageListenerContainer container; // RedisConfig 에서 제공
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper om;
+
+    @PostConstruct
+    void subscribe() {
+        container.addMessageListener(this, new PatternTopic(NotificationTopics.PATTERN_TRANSFERS_ALL));
+        log.info("[Transfers] Subscribed to {}", NotificationTopics.PATTERN_TRANSFERS_ALL);
+    }
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String json = new String(message.getBody(), StandardCharsets.UTF_8);
+            TransferWsDto payload = om.readValue(json, TransferWsDto.class);
+
+            // 그룹 브로드캐스트
+            String dest = NotificationTopics.wsTransfersDestination(payload.getGroupId());
+            messagingTemplate.convertAndSend(dest, payload);
+            log.debug("[Transfers] WS broadcast to {} :: {}", dest, json);
+
+            // 선택: 개인 알림도 함께
+            if (payload.getToMemberId() != null) {
+                String userDest = NotificationTopics.wsUserNotificationDestination(payload.getToMemberId());
+                messagingTemplate.convertAndSend(userDest, payload);
+                log.debug("[Transfers] WS unicast to {} :: {}", userDest, json);
+            }
+        } catch (Exception e) {
+            log.warn("[Transfers] failed handle pubsub", e);
+        }
+    }
+}


### PR DESCRIPTION
### 📌 목적 (Why)
- 정산/송금 이벤트를 Redis Pub/Sub → WebSocket으로 실시간 전파

### 🔧 변경 사항 (What)
- **Topics**: transfers:{groupId}, /topic/groups/{groupId}/transfers
- **Publisher/Subscriber**: TransferEventPublisher, TransferRedisSubscriber
- **DTO**: TransferWsDto (payload 표준화)
- **연동**: TransferService 상태 전이 지점에 publish 훅 추가
 

### 🔗 이슈 링크 (Related)
- Parent: #42 (MVP-5: 정산/지출)
- Related: #48 