### PR TITLE
feat(auth): 마이페이지 이름 수정 API 추가

### DIFF
--- a/src/main/java/com/gatieottae/backend/api/auth/dto/UpdateMeRequestDto.java
+++ b/src/main/java/com/gatieottae/backend/api/auth/dto/UpdateMeRequestDto.java
@@ -1,0 +1,11 @@
+package com.gatieottae.backend.api.auth.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateMeRequestDto(
+        @NotBlank
+        @Size(max = 100)
+        String name
+) {}

--- a/src/main/java/com/gatieottae/backend/domain/member/Member.java
+++ b/src/main/java/com/gatieottae/backend/domain/member/Member.java
@@ -14,13 +14,13 @@ import java.time.OffsetDateTime;
  * - username/password 기반의 로컬 회원가입
  * - email은 선택(Nullable)
  * - createdAt/updatedAt은 BaseTimeEntity에서 자동 세팅
- *
  * ⚠️ 유니크 제약
  * - username: DB/JPA 모두 유니크
  * - email: "값이 있을 때만 유니크"는 DB 파셜 인덱스로 처리 (JPA @Table uniqueConstraints로는 표현 불가)
  */
 
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 프록시용
 @AllArgsConstructor(access = AccessLevel.PRIVATE)  // 빌더 전용
 @Builder
@@ -143,4 +143,7 @@ public class Member extends BaseTimeEntity {
         this.lastLoginAt = (at == null) ? OffsetDateTime.now() : at;
     }
 
+    public void changeName(String newName) {
+        this.name = newName;
+    }
 }

--- a/src/main/java/com/gatieottae/backend/service/auth/MeService.java
+++ b/src/main/java/com/gatieottae/backend/service/auth/MeService.java
@@ -1,0 +1,30 @@
+package com.gatieottae.backend.service.auth;
+
+import com.gatieottae.backend.domain.member.Member;
+import com.gatieottae.backend.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MeService {
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public Member getMeByUsername(String username) {
+        return memberRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalStateException("회원 정보를 찾을 수 없습니다. username=" + username));
+    }
+
+    @Transactional
+    public Member updateName(String username, String newName) {
+        String trimmed = newName == null ? "" : newName.trim();
+        if (trimmed.isEmpty() || trimmed.length() > 100) {
+            throw new IllegalArgumentException("INVALID_NAME");
+        }
+        Member m = getMeByUsername(username);
+        m.changeName(trimmed); // JPA 변경 감지
+        return m;
+    }
+}


### PR DESCRIPTION
### 📌 목적 (Why)
- 마이페이지(MVP-6) 최소 기능 중 **이름 수정 API**를 백엔드에 구현
- 사용자 프로필에서 이름 변경 → DB 반영 → 갱신된 정보 반환

---

### 🔧 변경 사항 (What)
- **컨트롤러**: `AuthController`
  - `PUT /api/auth/me` 엔드포인트 추가
- **서비스**: `MeService`
  - `updateName(username, name)` 로직 구현
- **도메인**: `Member`
  - `changeName(newName)` 도메인 메서드 추가
- **DTO**: `UpdateMeRequestDto`
  - 요청 DTO 생성

---

### 🔗 이슈 링크 (Related Issues) 
- Parent: #53 